### PR TITLE
Updated Quiet Loom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@
 
 plugins {
     id("org.jetbrains.kotlin.jvm").version("1.8.22")
-    id("quiet-fabric-loom") version "1.2-SNAPSHOT"
+    id("quiet-fabric-loom") version "1.4-SNAPSHOT"
 }
 
 val modId = project.properties["mod_id"].toString()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@ pluginManagement {
             url = 'https://maven.fabricmc.net/'
         }
         gradlePluginPortal()
+        mavenLocal()
         maven {
             name = 'Quiet Loom'
             url = 'https://repo.jpenilla.xyz/snapshots/'


### PR DESCRIPTION
Updated Quiet Loom to version 1.4 and Gradle Wrapper to version 8.3.

Note:
Quiet Loom version 1.4 needed to be built locally because the official repositories are offline.