### PR TITLE
add: Kit claimed event

### DIFF
--- a/src/main/kotlin/com/pokeskies/skieskits/config/Kit.kt
+++ b/src/main/kotlin/com/pokeskies/skieskits/config/Kit.kt
@@ -2,6 +2,7 @@ package com.pokeskies.skieskits.config
 
 import com.google.gson.annotations.SerializedName
 import com.pokeskies.skieskits.SkiesKits
+import com.pokeskies.skieskits.events.KitClaimedEvent
 import com.pokeskies.skieskits.config.actions.ActionOptions
 import com.pokeskies.skieskits.config.item.KitItem
 import com.pokeskies.skieskits.config.item.MenuItem
@@ -122,6 +123,12 @@ class Kit(
         }
 
         Utils.printDebug("Player ${player.name.string} successfully claimed kit $kitId!")
+
+        try {
+            KitClaimedEvent.EVENT.invoker().onKitClaimed(player, kitId)
+        } catch (e: Exception) {
+            Utils.printError("Error invoking KitClaimedEvent for kit $kitId: ${e.message}")
+        }
 
         actions.executeClaimedActions(player, kitId, this, kitData)
 

--- a/src/main/kotlin/com/pokeskies/skieskits/events/KitClaimedEvent.kt
+++ b/src/main/kotlin/com/pokeskies/skieskits/events/KitClaimedEvent.kt
@@ -1,0 +1,17 @@
+package com.pokeskies.skieskits.events
+
+import net.fabricmc.fabric.api.event.Event
+import net.fabricmc.fabric.api.event.EventFactory
+import net.minecraft.server.level.ServerPlayer
+
+fun interface KitClaimedEvent {
+    fun onKitClaimed(player: ServerPlayer, kitId: String)
+
+    companion object {
+        val EVENT: Event<KitClaimedEvent> = EventFactory.createArrayBacked(KitClaimedEvent::class.java) { listeners ->
+            KitClaimedEvent { player, kitId ->
+                listeners.forEach { it.onKitClaimed(player, kitId) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Review Type** Feature

**Short version:** Adds an event when a kit is redeemed by a player. Exposes player and kit ID

**Long version**
Event ran when a player redeems a kit (after reward). Needed it for my uses and figured I might as well put it on here too

No planned changes based on this PR, feel free to close/contribute if you're not happy with anything :)
